### PR TITLE
chore(deps): Update ChatBot version/prop name

### DIFF
--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@patternfly/patternfly": "^6.0.0",
     "@patternfly/quickstarts": "^6.0.0-alpha.0",
-    "@patternfly/chatbot": "2.1.0-prerelease.26",
+    "@patternfly/chatbot": "^2.2.0-prerelease.19",
     "@patternfly/react-core": "^6.0.0",
     "i18next": "^19.8.3",
     "i18next-browser-languagedetector": "^8.0.0",

--- a/packages/dev/src/AppTabs.tsx
+++ b/packages/dev/src/AppTabs.tsx
@@ -240,7 +240,7 @@ const App: React.FC<AppProps> = ({ children, showCardFooters }) => {
         timestamp: date.toLocaleString(),
         quickStarts: {
           quickStart: yamlQuickStarts[0],
-          onFooterClick: (id: string) => {
+          onSelectQuickStart: (id: string) => {
             setActiveQuickStartID(id);
             setActiveTabKey(1);
           },


### PR DESCRIPTION
We need to remove the min-content on the QuickStarts tile and maybe target the response actions better. Otherwise this seems ok?